### PR TITLE
Add namespace placeholders where needed

### DIFF
--- a/document-generator-files/birds.json
+++ b/document-generator-files/birds.json
@@ -5,7 +5,7 @@
           "birdImage": {
                "source": "OBJECT_STORAGE",
                "objectName": "penguin.png",
-               "namespace": "idsvv7k2bdum",
+               "namespace": "<put-namespace-here>",
                "bucketName": "fun_oci_functions_bucket",
                "mediaType": "image/png",
                "height": "140px"
@@ -21,7 +21,7 @@
           "birdImage": {
                "source": "OBJECT_STORAGE",
                "objectName": "toucan.png",
-               "namespace": "idsvv7k2bdum",
+               "namespace": "<put-namespace-here>",
                "bucketName": "fun_oci_functions_bucket",
                "mediaType": "image/png",
                "height": "140px"
@@ -40,7 +40,7 @@
           "birdImage": {
                "source": "OBJECT_STORAGE",
                "objectName": "albatross.png",
-               "namespace": "idsvv7k2bdum",
+               "namespace": "<put-namespace-here>",
                "bucketName": "fun_oci_functions_bucket",
                "mediaType": "image/png",
                "height": "140px"

--- a/request.txt
+++ b/request.txt
@@ -1,7 +1,7 @@
 oci fn function invoke --function-id <put-function-ocid-here> --file "-" --body '{
     "requestType": "SINGLE",
     "tagSyntax": "DOCGEN_1_0",
-    "data": {    
+    "data": {
       "source": "OBJECT_STORAGE",
       "namespace": "<put-namespace-here>",
       "bucketName": "fun_oci_functions_bucket",
@@ -23,5 +23,3 @@ oci fn function invoke --function-id <put-function-ocid-here> --file "-" --body 
       "contentType": "application/pdf"
     }
 }' | jq
-
-


### PR DESCRIPTION
The [blog post](https://francois-robert.ghost.io/fun-with-oci-functions-part-1/) asks to replace `<put-namespace-here>` only in file `request.txt`. To make the OCI Function call work, I also had to use my own namespace in a few places in `birds.json`.

I'm not sure if it's the proper fix, but it allowed me to generate a PDF as intended.

Error message before this change:

> OBS828 Error reading 'penguin.png' from Object Storage: Error returned by GetObject operation in ObjectStorage service.(404, BucketNotFound, false) Either the bucket named 'fun_oci_functions_bucket' does not exist in the namespace 'idsvv7k2bdum' or you are not authorized to access it 

